### PR TITLE
DOC: add links to JSON model

### DIFF
--- a/docs/julia/lb2pkg-lhcb-2765817.qmd
+++ b/docs/julia/lb2pkg-lhcb-2765817.qmd
@@ -4,6 +4,10 @@ jupyter: julia-amplitude-serialization-1.10
 
 # $\Lambda_b^0 \to p K^- \gamma$
 
+::: {.callout-note appearance="simple"}
+Model definition: [`lb2pkg-lhcb-2765817.json`](https://github.com/RUB-EP1/amplitude-serialization/blob/main/models/lb2pkg-lhcb-2765817.json).
+:::
+
 This page demonstrates deserialization and evaluation of an amplitude model for the decay $\Lambda_b^0 \to p K^- \gamma$. The resonant structure is studied using proton-proton collision data recorded at centre-of-mass energies of $7$, $8$, and $13$ TeV collected with the LHCb detector, [INSPIRE-HEP 2765817](https://inspirehep.net/literature/2765817).
 
 ```{julia}

--- a/docs/julia/lc2ppik-lhcb-2683025.qmd
+++ b/docs/julia/lc2ppik-lhcb-2683025.qmd
@@ -4,6 +4,10 @@ jupyter: julia-amplitude-serialization-1.10
 
 # $\Lambda_c^+ \to p K^- \pi^+$
 
+::: {.callout-note appearance="simple"}
+Model definition: [`lc2ppik-lhcb-2683025.json`](https://github.com/RUB-EP1/amplitude-serialization/blob/main/models/lc2ppik-lhcb-2683025.json).
+:::
+
 This page demonstrates deserialization and evaluation of an amplitude model for the decay $\Lambda_c^+ \to p K^- \pi^+$. The amplitude analysis is performed based on roughly half a million of $\Lambda_c^{\pm}$ decay candidates by the LHCb collaboration, [INSPIRE-HEP 2683025](https://inspirehep.net/literature/2683025). Details on the mapped of the amplitude model onto the standard helicity formalism can be found in appendix of [INSPIRE-HEP 2623821](https://inspirehep.net/literature/2623821).
 
 ```{julia}

--- a/docs/julia/x2pipipi-compass-1391643.qmd
+++ b/docs/julia/x2pipipi-compass-1391643.qmd
@@ -4,6 +4,10 @@ jupyter: julia-amplitude-serialization-1.10
 
 # $X\to \pi^-\pi^+\pi^-$
 
+::: {.callout-note appearance="simple"}
+Model definition: [`x2pipipi-compass-1391643.json`](https://github.com/RUB-EP1/amplitude-serialization/blob/main/models/x2pipipi-compass-1391643.json).
+:::
+
 This page demonstrates deserialization and evaluation the a partial wave analysis of diffractively produced $3\pi$ system. The analysis is performed independently in bins of $3\pi$ mass, and transferred momentum. The total number of bins is 100.
 For every bin, the model includes about 170 decay chains (about 88 waves, symmetrized for two $\pi^+\pi^-$ pairs). The main paper describing details of the analysis is [INSPIRE-HEP 1391643](https://inspirehep.net/literature/1391643).
 

--- a/docs/python/lc2ppik-lhcb-2683025.qmd
+++ b/docs/python/lc2ppik-lhcb-2683025.qmd
@@ -3,6 +3,11 @@ jupyter: python3
 ---
 
 # $\Lambda_c^+ \to p K^- \pi^+$c
+
+::: {.callout-note appearance="simple"}
+Model definition: [`lc2ppik-lhcb-2683025.json`](https://github.com/RUB-EP1/amplitude-serialization/blob/main/models/lc2ppik-lhcb-2683025.json).
+:::
+
 This notebooks illustrates the use of the [`ampform_dpd.io.serialization`](https://ampform-dpd.rtfd.io/0.2.1rc1/api/ampform_dpd.io.serialization.html) module for the decay $\Lambda_c^+ \to p K^- \pi^+$. The corresponding model was optimized to a data sample of roughly half a million $\Lambda_c^{\pm}$ decay candidates by the LHCb collaboration, [INSPIRE-HEP 2683025](https://inspirehep.net/literature/2683025).
 
 ::: {.callout-warning}


### PR DESCRIPTION
Closes #51 

- Not really an automated solution, but I'm not sure if Quarto has good templating features for this.
- I was doubting between embedding the file in the pages and linking to the source on GitHub.
  - Embedding: [good] link is always synced with the main branch, [bad] it will download the file
  - Link to GitHub: [good] nicer language navigation of the JSON file, [bad] there are no checks whether external links still exist.
- Settled on link to the source code on GitHub in the end