### PR TITLE
`pyroot` using `RooJSONFactoryWSTool`

### DIFF
--- a/docs/python/spectrum-lhcb.py
+++ b/docs/python/spectrum-lhcb.py
@@ -1,0 +1,19 @@
+import ROOT
+from ROOT import RooRealVar, RooGaussian, RooWorkspace
+from ROOT import RooJSONFactoryWSTool
+
+
+def export_pdf():
+    x = RooRealVar("x", "x", -10, 10)
+    mean = RooRealVar("mean", "mean of gaussian", 1, -10, 10)
+    sigma = RooRealVar("sigma", "width of gaussian", 1, 0.1, 10)
+    gauss = RooGaussian("gauss", "gaussian PDF", x, mean, sigma)
+
+    w = RooWorkspace("ws")
+    getattr(w, 'import')(gauss)
+
+    tool = RooJSONFactoryWSTool(w)
+    tool.exportJSON("gauss.json")
+    return 0
+
+export_pdf()


### PR DESCRIPTION
Related to #58 

This pull request should demonstrate how to deal with `json` files with `pyroot`

- [ ] add relevant `json` - something simple with already registered pdfs
- [ ] add `root` recipe to `pixi`
- [ ] add `pyroot` page with links to HS3