### PR TITLE
FEAT: push docs preview for pull requests

### DIFF
--- a/.cspell/project.txt
+++ b/.cspell/project.txt
@@ -1,9 +1,10 @@
 callout
+isinstance
 lhcb
 Mikhasenko
 Misha
 multline
 pdfs
-ppik
 pipipi
+ppik
 semileptonic

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,7 +62,7 @@ jobs:
           path: docs/_build/html
 
   pr-preview:
-    name: Push PR preview
+    name: PR preview
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository
@@ -85,13 +85,13 @@ jobs:
           git init
           git checkout --orphan gh-pages
           git add -A
-          git commit -m "Push preview for https://github.com/RUB-EP1/amplitude-serialization/pull/${{ github.event.number }}"
+          git commit -m "https://github.com/RUB-EP1/amplitude-serialization/pull/${{ github.event.number }} preview at https://rub-ep1.github.io/amplitude-serialization-pr-preview"
       - name: Push results to GitHub Pages
         run: |
           git remote add origin https://x-access-token:${{ secrets.PAT }}@github.com/RUB-EP1/amplitude-serialization-pr-preview
           git push origin gh-pages --force
-      - name: Show notice with link to PR preview
-        run: echo "::notice title=Documentation preview::https://rub-ep1.github.io/amplitude-serialization-pr-preview"
+      - name: Show link to PR preview
+        run: echo "Documentation preview available on [rub-ep1.github.io/amplitude-serialization-pr-preview](https://rub-ep1.github.io/amplitude-serialization-pr-preview)" >> $GITHUB_STEP_SUMMARY
 
   deploy:
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v6
         with:
           key: |
-            jupyter-cache-${{hashFiles('pixi.lock')}}-${{hashFiles('docs/*/*.md')}}
+            jupyter-cache-${{hashFiles('pixi.lock')}}-${{hashFiles('docs/*/*.qmd')}}
           restore-keys: |
             jupyter-cache-${{hashFiles('pixi.lock')}}
             jupyter-cache
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v6
         with:
           key: |
-            home-cache-${{hashFiles('pixi.lock')}}-${{hashFiles('docs/*/*.md')}}
+            home-cache-${{hashFiles('pixi.lock')}}-${{hashFiles('docs/*/*.qmd')}}
           restore-keys: |
             home-cache-${{hashFiles('pixi.lock')}}
             home-cache

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v6
         with:
           key: |
-            jupyter-cache-${{hashFiles('pixi.lock')}}-${{hashFiles('docs/*/*.qmd')}}
+            jupyter-cache-${{hashFiles('pixi.lock')}}-${{hashFiles('docs/*/*.qmd', 'models/*.json')}}
           restore-keys: |
             jupyter-cache-${{hashFiles('pixi.lock')}}
             jupyter-cache
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v6
         with:
           key: |
-            home-cache-${{hashFiles('pixi.lock')}}-${{hashFiles('docs/*/*.qmd')}}
+            home-cache-${{hashFiles('pixi.lock')}}-${{hashFiles('docs/*/*.qmd', 'models/*.json')}}
           restore-keys: |
             home-cache-${{hashFiles('pixi.lock')}}
             home-cache

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,24 +72,38 @@ jobs:
       - uses: actions/download-artifact@v7
         with:
           name: github-pages
-      - name: Extract artifact
-        run: |
-          tar xf artifact.tar
-          rm artifact.tar
       - name: Configure Git credentials
         run: |
           git config --global user.name "GitHub Action"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Initialize repository and commit results
+      - name: Check out preview branch
         run: |
+          mkdir preview
+          cd preview
           git init
-          git checkout --orphan gh-pages
-          git add -A
-          git commit -m "https://github.com/RUB-EP1/amplitude-serialization/pull/${{ github.event.number }} preview at https://rub-ep1.github.io/amplitude-serialization-pr-preview"
-      - name: Push results to GitHub Pages
-        run: |
           git remote add origin https://x-access-token:${{ secrets.PAT }}@github.com/RUB-EP1/amplitude-serialization-pr-preview
-          git push origin gh-pages --force
+          if git fetch --depth=1 origin gh-pages; then
+            git checkout -B gh-pages FETCH_HEAD
+            git rm -rf .
+          else
+            git checkout --orphan gh-pages
+          fi
+      - name: Extract artifact
+        run: |
+          tar xf artifact.tar -C preview
+          rm artifact.tar
+      - name: Commit results
+        working-directory: preview
+        run: |
+          git add -A
+          if git rev-parse --verify HEAD; then
+            git commit --amend -m "https://github.com/RUB-EP1/amplitude-serialization/pull/${{ github.event.number }} preview at https://rub-ep1.github.io/amplitude-serialization-pr-preview"
+          else
+            git commit -m "https://github.com/RUB-EP1/amplitude-serialization/pull/${{ github.event.number }} preview at https://rub-ep1.github.io/amplitude-serialization-pr-preview"
+          fi
+      - name: Push results to GitHub Pages
+        working-directory: preview
+        run: git push origin gh-pages --force
       - name: Show link to PR preview
         run: echo "Documentation preview available on [rub-ep1.github.io/amplitude-serialization-pr-preview](https://rub-ep1.github.io/amplitude-serialization-pr-preview)" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,8 +61,7 @@ jobs:
         with:
           path: docs/_build/html
 
-  pr-preview:
-    name: PR preview
+  preview:
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,6 +61,38 @@ jobs:
         with:
           path: docs/_build/html
 
+  pr-preview:
+    name: Push PR preview
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: github-pages
+      - name: Extract artifact
+        run: |
+          tar xf artifact.tar
+          rm artifact.tar
+      - name: Configure Git credentials
+        run: |
+          git config --global user.name "GitHub Action"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Initialize repository and commit results
+        run: |
+          git init
+          git checkout --orphan gh-pages
+          git add -A
+          git commit -m "Push preview for https://github.com/RUB-EP1/amplitude-serialization/pull/${{ github.event.number }}"
+      - name: Push results to GitHub Pages
+        run: |
+          git remote add origin https://x-access-token:${{ secrets.PAT }}@github.com/RUB-EP1/amplitude-serialization-pr-preview
+          git push origin gh-pages --force
+      - name: Show notice with link to PR preview
+        run: echo "::notice title=Documentation preview::https://rub-ep1.github.io/amplitude-serialization-pr-preview"
+
   deploy:
     environment:
       name: github-pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 *.egg-info/
+.agents/
+.claude/
+.codex/
 .ipynb_checkpoints/
 .pixi/
 .virtual_documents/
 _build/
+AGENTS.md
+CLAUDE.md
 node_modules/

--- a/docs/python/lc2ppik-lhcb-2683025.qmd
+++ b/docs/python/lc2ppik-lhcb-2683025.qmd
@@ -269,21 +269,59 @@ The following serves as a numerical check on whether the amplitude model has bee
 
 ```{python}
 # | code-fold: true
-# | column: page-inset-right
-checksums = {
-    misc_key: {checksum["point"]: checksum["value"] for checksum in misc_value}
-    for misc_key, misc_value in MODEL_DEFINITION["misc"].items()
-    if "checksum" in misc_key
-}
-assert len(checksums) == 1, "Expected only one checksum entry"
-checksums["amplitude_model_checksums"]
-```
-
-```{python}
-# | code-fold: true
 checksum_points = {
     point["name"]: {par["name"]: par["value"] for par in point["parameters"]}
     for point in MODEL_DEFINITION["parameter_points"]
 }
-checksum_points
+```
+
+The table lists the validation checks and their status. The marks "🟢", "🟡", and "🔴"
+indicate an accuracy of $<10^{-10}$, $<10^{-2}$, or $\ge10^{-2}$, respectively, for
+the difference between the reference and computed values.
+
+```{python}
+# | code-fold: true
+# | code-summary: Validate serialized propagators
+def to_complex(value: float | str) -> complex:
+    if isinstance(value, str):
+        return complex(value.replace(" ", "").replace("i", "j"))
+    return complex(value)
+
+
+def label_diff(difference: complex) -> str:
+    absolute_difference = abs(difference)
+    if absolute_difference < 1e-10:
+        return "🟢"
+    if absolute_difference < 1e-2:
+        return "🟡"
+    return "🔴"
+
+
+chains_by_propagator = {
+    propagator["parametrization"]: chain
+    for chain in CHAIN_DEFS
+    for propagator in chain["propagators"]
+}
+validation_results = []
+for checksum in MODEL_DEFINITION["misc"]["amplitude_model_checksums"]:
+    distribution_name = checksum["distribution"]
+    chain = chains_by_propagator.get(distribution_name)
+    if chain is None:
+        continue
+    dynamics = formulate_dynamics(chain, MODEL_DEFINITION)
+    function = perform_cached_lambdify(
+        dynamics.expression.doit(),
+        parameters=dynamics.parameters,
+    )
+    point = checksum_points[checksum["point"]]
+    variable = next(iter(dynamics.expression.free_symbols - dynamics.parameters.keys()))
+    computed_value = function({str(variable): next(iter(point.values()))})
+    reference_value = to_complex(checksum["value"])
+    validation_results.append({
+        "Distribution": distribution_name,
+        "Point": checksum["point"],
+        "Status": label_diff(reference_value - computed_value),
+    })
+
+pd.DataFrame(validation_results)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ julia --project -e '
 '
 """
 
+[tool.pixi.tasks.style]
+cmd = "pre-commit run --all-files"
+description = "Perform all linting, formatting, and spelling checks"
+
 [tool.pixi.tasks.upgrade]
 depends-on = [
     "_upgrade-pixi",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,18 @@ PYTHONHASHSEED = "0"
 juliaup = "*"
 python = "3.13.*"
 
+[tool.pixi.tasks.all]
+depends-on = [
+    "style",
+    "_clean-doc",
+    "doc",
+]
+description = "Run all continuous integration (CI) tasks locally"
+
+[tool.pixi.tasks._clean-doc]
+cmd = "rm -rf docs/.quarto docs/_build"
+description = "Remove generated documentation build files"
+
 [tool.pixi.tasks.doc]
 cmd = "quarto render"
 cwd = "docs"


### PR DESCRIPTION
Closes #97

## ✨ New features

- Push a documentation preview to a dedicated `amplitude-serialization-pr-preview` GitHub Pages repo whenever a PR is opened from a branch in this repository, with a link posted as a workflow notice.

## ⚙️ Enhancements

- **[Python]** Replace the raw checksum dump in the validation notebook with a results table that reports, per propagator distribution and parameter point, a 🟢/🟡/🔴 status mark that reflects the accuracy of the computed value against the reference checksum.

## 🖱️ Developer experience

- Add a `pixi run style` task that runs all pre-commit checks.
- Add a `pixi run all` task that runs `style` and `doc` (after clearing generated build files) to reproduce CI locally.
- Ignore local AI-agent configuration directories and files (`.claude/`, `.codex/`, `.agents/`, `CLAUDE.md`, `AGENTS.md`).
- Fix the documentation build cache key, which hashed `docs/*/*.md` instead of the actual `.qmd` source files.
- Extend the cache key to also hash `models/*.json`, so changes to example models correctly invalidate the cache.

## Squash commit messages

```text
* DX: add agent configurations to `.gitignore`
* DX: define `pixi run all` task
* DX: define `pixi run style` task
* DX: implement validation table
* FIX: add JSON models to cache hashes as well
* FIX: hash caches with regard to `qmd` files
```